### PR TITLE
add SauceLabs video config options to default ini

### DIFF
--- a/saunter/_defaults/conf/saunter.ini.default
+++ b/saunter/_defaults/conf/saunter.ini.default
@@ -38,6 +38,12 @@ ondemand: false
 get_video: true
 get_log: true
 
+# If your tests on SauceLabs run more than 3x as long as local test runs, 
+# disable the option to upload video on passing tests and gauge the performance impact. 
+# If no different, disable recording the video altogether and guage the performance impact.
+record_video: true
+video_upload_on_pass: false
+
 # Your Sauce Labs username and API key
 username: your_username
 key: your-key

--- a/saunter/testcase/webdriver.py
+++ b/saunter/testcase/webdriver.py
@@ -117,6 +117,8 @@ class SaunterTestCase(BaseTestCase):
                 "platform": self.cf.get("SauceLabs", "os"),
                 "browserName": self.cf.get("SauceLabs", "browser"),
                 "version": self.cf.get("SauceLabs", "browser_version"),
+                "record-video": self.cf.get("SauceLabs", "record_video"),
+                "video-upload-on-pass": self.cf.get("SauceLabs", "video_upload_on_pass"),
                 "name": method.__name__
             }
             if desired_capabilities["browserName"][0] == "*":


### PR DESCRIPTION
SauceLabs support, in their tips for speedy tests (http://support.saucelabs.com/entries/23388772-Tips-for-lean-speedy-tests), advises that users consider disabling video options. Here we add both configs to the saunter.ini.default for users to easily toggle.
