### PR TITLE
docs: fix simple typo, timout -> timeout

### DIFF
--- a/saunter/po/__init__.py
+++ b/saunter/po/__init__.py
@@ -29,7 +29,7 @@ if "timeout" in cf["selenium"]:
 else:
     timeout_seconds = 30
 
-#: timout value in ms as an integer
+#: timeout value in ms as an integer
 timeout_microseconds = timeout_seconds * 1000
-#: timout value in ms as a string
+#: timeout value in ms as a string
 string_timeout = str(timeout_microseconds)


### PR DESCRIPTION
There is a small typo in saunter/po/__init__.py.

Should read `timeout` rather than `timout`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md